### PR TITLE
Fix vals2coefs implementations to properly treat non-contiguous data

### DIFF
--- a/c++/cppdlr/dlr_imtime.hpp
+++ b/c++/cppdlr/dlr_imtime.hpp
@@ -92,24 +92,21 @@ namespace cppdlr {
 
       if (r != g.shape(0)) throw std::runtime_error("First dim of g != DLR rank r.");
 
-      // Reshape g to matrix w/ first dimension r
-      auto g_rs = nda::reshape(g, r, g.size() / r);
-      auto gct  = nda::matrix<S>(transpose(g_rs));
+      // Make a copy of the data in Fortran Layout as required by getrs
+      auto gf = nda::array<get_value_t<T>, get_rank<T>, F_layout>(g);
 
-      // Solve linear system (multiple right hand sides) to convert vals ->
-      // coeffs (we transpose because LAPACK requires index into RHS # to be
-      // slowest)
+      // Reshape as matrix_view with r rows
+      auto gfv = nda::reshape(gf, r, g.size() / r);
 
+      // Solve linear system (multiple right hand sides) to convert vals -> coeffs
       if constexpr (nda::have_same_value_type_v<T, decltype(it2cf.lu)>) {
-        nda::lapack::getrs(it2cf.lu, gct, it2cf.piv);
+        nda::lapack::getrs(it2cf.lu, gfv, it2cf.piv);
       } else {
         // getrs requires matrix and rhs to have same value type
-        nda::lapack::getrs(nda::matrix<S>(it2cf.lu), gct, it2cf.piv);
+        nda::lapack::getrs(nda::matrix<S>(it2cf.lu), gfv, it2cf.piv);
       }
 
-      // Reshape to original dimensions and return
-      auto gc = nda::matrix<S>(transpose(gct));
-      return nda::reshape(gc, g.shape());
+      return gf;
     }
 
     /** 


### PR DESCRIPTION
Fixes a problem in the vals2coefs implementation when the input data is non-contiguous.
Also simplifies the general function logic.

The previous call to reshape
```c++
auto g_rs = nda::reshape(g, r, g.size() / r);
```
expects the input data to be contiguous.