### PR TITLE
Fix range bug in imtime_ops.interp_matrix_sym_bos

### DIFF
--- a/test/c++/imtime_ops.cpp
+++ b/test/c++/imtime_ops.cpp
@@ -969,6 +969,9 @@ TEST(imtime_ops, interp_matrix_sym_bos) {
   auto dlr_rf = build_dlr_rf(lambda, eps, SYM);
   int r       = dlr_rf.size();
 
+  // Verify DLR rank is even
+  EXPECT_EQ(r % 2, 0);
+
   // Verify DLR rank is odd
   //EXPECT_EQ(r % 2, 1);
 
@@ -985,7 +988,8 @@ TEST(imtime_ops, interp_matrix_sym_bos) {
   auto const &dlr_it = itops.get_itnodes();
 
   // Verify symmetry
-  EXPECT_EQ(max_element(abs(dlr_it(range((r - 1) / 2)) + dlr_it(range(r - 1, (r - 1) / 2, -1)))), 0);
+  EXPECT_EQ(max_element(abs(dlr_it(range(r / 2)) + dlr_it(range(r - 1, r / 2 - 1, -1)))), 0); // r even
+  //EXPECT_EQ(max_element(abs(dlr_it(range((r - 1) / 2)) + dlr_it(range(r - 1, (r - 1) / 2, -1)))), 0); // r odd
 
   // Verify tau = 1/2 was selected
   //EXPECT_EQ(dlr_it((r - 1) / 2), 0.5);


### PR DESCRIPTION
This is a fix of a range error that only shows up when compiling and running the test in Debug mode.

```bash
cmake -DCMAKE_BUILD_TYPE=Debug  ...
```

I think we need to add a case in the continuous integration that runs the test with Debug enabled. Since this did not show up in the current automated tests.

Best, Hugo