### PR TITLE
[itops] split convmat in allocation and a convmat_inplace builder fun…

### DIFF
--- a/c++/cppdlr/dlr_imtime.hpp
+++ b/c++/cppdlr/dlr_imtime.hpp
@@ -490,12 +490,17 @@ namespace cppdlr {
     * diagrams using separable basis functions: Anderson impurity model strong
     * coupling expansion," arXiv:2307.08566 (2023).
     *
-    * @param[out] fconv Convolution matrix from DLR coefficients to DLR grid
+    * @param[in/out] fconv Convolution matrix from DLR coefficients to DLR grid
     * @param[in] beta Inverse temperature
     * @param[in] statistic Fermionic ("Fermion" or 0) or bosonic ("Boson" or 1)
     * @param[in] fc DLR coefficients of f
     * @param[in] time_order Flag for ordinary (false or ORDINARY, default) or
     * time-ordered (true or TIME_ORDERED) convolution
+    *
+    * \note This function builds the matrix of convolution, in place, in the
+    * provided matrix `fconv`. This makes it possible to control the memory
+    * allocation externally. If this is not a concern, we advice using the
+    * `covmat(...)` function instead (of `convmat_inplace(...)`).
     *
     * \note Whereas the method imtime_ops::convolve takes the DLR coefficients
     * of f and g as input and computes their convolution h directly, this method

--- a/c++/cppdlr/dlr_imtime.hpp
+++ b/c++/cppdlr/dlr_imtime.hpp
@@ -471,6 +471,7 @@ namespace cppdlr {
 
     /**
     * @brief Compute matrix of convolution by an imaginary time Green's function
+    * in place
     *
     * The convolution of f and g is defined as h(t) = (f * g)(t) = int_0^beta
     * f(t-t') g(t') dt', where fermionic/bosonic antiperiodicity/periodicity are
@@ -499,8 +500,8 @@ namespace cppdlr {
     *
     * \note This function builds the matrix of convolution, in place, in the
     * provided matrix `fconv`. This makes it possible to control the memory
-    * allocation externally. If this is not a concern, we advice using the
-    * `covmat(...)` function instead (of `convmat_inplace(...)`).
+    * allocation externally. If this is not a concern, we advise using the
+    * `convmat(...)` function instead of `convmat_inplace(...)`.
     *
     * \note Whereas the method imtime_ops::convolve takes the DLR coefficients
     * of f and g as input and computes their convolution h directly, this method


### PR DESCRIPTION
Dear Jason,

I have been struggling with `imtime_ops.convmat` for systems having a large number of orbitals. The main challenge has been that of getting control of allocations, so that the large convolution matrix is only allocated once.

This pull requests splits the current `imtime_ops.convmat` in two functions, retaining the API of the `convmat` and adding a `convmat_inplace` method that builds the matrix in-place using a passed matrix_view. This way it is possible for the library user to take control over the allocation. 

I am currently using it on 1.1.x (and this is a pull request to the 1.1.x. branch), together with Triqs 1.3.x (that depends on cppdlr 1.1.x).

Cheers, Hugo